### PR TITLE
Change config filenames only while running RuboCopRunner

### DIFF
--- a/lib/rdoc_rubocop/rubocop_modifier.rb
+++ b/lib/rdoc_rubocop/rubocop_modifier.rb
@@ -57,13 +57,33 @@ module RDocRuboCop
         end
       end
     end
+
+    module ConfigLoaderModifier
+      DOTFILE = ".rdoc_rubocop.yml".freeze
+      AUTO_GENERATED_FILE = ".rdoc_rubocop_todo.yml".freeze
+
+      def change_dotfilenames_temporary
+        dotfile_backup = RuboCop::ConfigLoader::DOTFILE
+        auto_generated_file_backup = RuboCop::ConfigLoader::AUTO_GENERATED_FILE
+
+        redefine_const(:DOTFILE, DOTFILE)
+        redefine_const(:AUTO_GENERATED_FILE, AUTO_GENERATED_FILE)
+
+        yield
+      ensure
+        redefine_const(:DOTFILE, dotfile_backup)
+        redefine_const(:AUTO_GENERATED_FILE, auto_generated_file_backup)
+      end
+
+      private
+
+      def redefine_const(const_name, value)
+        RuboCop::ConfigLoader.send(:remove_const, const_name)
+        RuboCop::ConfigLoader.const_set(const_name, value)
+      end
+    end
   end
 end
 
 RuboCop::Runner.prepend RDocRuboCop::RuboCopModifier::RunnerModifier
 RuboCop::Cop::Team.prepend RDocRuboCop::RuboCopModifier::TeamModifier
-
-RuboCop::ConfigLoader.send(:remove_const, :DOTFILE)
-RuboCop::ConfigLoader.const_set(:DOTFILE, ".rdoc_rubocop.yml".freeze)
-RuboCop::ConfigLoader.send(:remove_const, :AUTO_GENERATED_FILE)
-RuboCop::ConfigLoader.const_set(:AUTO_GENERATED_FILE, ".rdoc_rubocop_todo.yml".freeze)

--- a/lib/rdoc_rubocop/rubocop_runner.rb
+++ b/lib/rdoc_rubocop/rubocop_runner.rb
@@ -44,8 +44,13 @@ module RDocRuboCop
       end
     end
 
+    require "rdoc_rubocop/rubocop_modifier"
+    include RDocRuboCop::RuboCopModifier::ConfigLoaderModifier
+
     def run_cli(source_code_file_paths)
-      @cli.run(@options + source_code_file_paths)
+      change_dotfilenames_temporary do
+        @cli.run(@options + source_code_file_paths)
+      end
     end
 
     def source_files

--- a/spec/rdoc_rubocop/rubocop_modifier_spec.rb
+++ b/spec/rdoc_rubocop/rubocop_modifier_spec.rb
@@ -47,4 +47,32 @@ RSpec.describe RDocRuboCop::RuboCopModifier do
       )
     end
   end
+
+  describe RDocRuboCop::RuboCopModifier::ConfigLoaderModifier do
+    describe "#change_dotfilenames_temporary" do
+      subject do
+        klass =
+          Class.new do
+            include RDocRuboCop::RuboCopModifier::ConfigLoaderModifier
+          end
+
+        klass.new.change_dotfilenames_temporary do
+          [
+            RuboCop::ConfigLoader::DOTFILE,
+            RuboCop::ConfigLoader::AUTO_GENERATED_FILE,
+          ]
+        end
+      end
+
+      it "should change filenames" do
+        is_expected.to eq([".rdoc_rubocop.yml", ".rdoc_rubocop_todo.yml"])
+      end
+
+      it "should restore original filenames" do
+        subject
+        expect(RuboCop::ConfigLoader::DOTFILE).to eq(".rubocop.yml")
+        expect(RuboCop::ConfigLoader::AUTO_GENERATED_FILE).to eq(".rubocop_todo.yml")
+      end
+    end
+  end
 end


### PR DESCRIPTION
RDocRuboCop changes `DOTFILE` and `AUTO_GENERATED_FILE` to automatically generate files with names different from RuboCop.
But the effect of this change also extends to RuboCop.

To avoid this, change filenames before executing RDocRubocop and restore it after execution.