### PR TITLE
Separate adjacent comments

### DIFF
--- a/lib/rdoc_rubocop/comment_extractor.rb
+++ b/lib/rdoc_rubocop/comment_extractor.rb
@@ -21,7 +21,7 @@ module RDocRuboCop
     private
 
     def comment_tokens
-      tokens.select(&:on_comment?)
+      tokens.select(&:comment?)
     end
 
     def tokens

--- a/lib/rdoc_rubocop/token.rb
+++ b/lib/rdoc_rubocop/token.rb
@@ -26,7 +26,7 @@ module RDocRuboCop
       @locate[1]
     end
 
-    def on_comment?
+    def comment?
       false
     end
   end

--- a/lib/rdoc_rubocop/token.rb
+++ b/lib/rdoc_rubocop/token.rb
@@ -26,8 +26,12 @@ module RDocRuboCop
       @locate[1]
     end
 
-    def comment?
-      false
+    %i(on_sp on_comment).each do |type|
+      class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        def #{type.to_s.sub(/^on_/, "")}? # def sp?
+          type == :#{type}                #   type == :on_sp
+        end                               # end
+      RUBY
     end
   end
 end

--- a/lib/rdoc_rubocop/token/comment_token.rb
+++ b/lib/rdoc_rubocop/token/comment_token.rb
@@ -10,7 +10,7 @@ module RDocRuboCop
           SPACE_CHAR * indent_after_comment
       end
 
-      def on_comment?
+      def comment?
         true
       end
 

--- a/spec/rdoc_rubocop/comment_extractor_spec.rb
+++ b/spec/rdoc_rubocop/comment_extractor_spec.rb
@@ -49,5 +49,37 @@ RSpec.describe RDocRuboCop::CommentExtractor do
         expect(subject[1].comment_tokens[2].token).to eq("# comment-in-Foo-3\n")
       end
     end
+
+    context "when two comments are adjacent" do
+      let(:source) do
+        <<-RUBY.strip_heredoc
+          class Foo
+            #--
+            # comment
+            def foo # :nodoc:
+              "foo"
+            end
+            module_function :foo
+          end
+        RUBY
+      end
+
+      it "should returns two instances of Comment" do
+        expect(subject.size).to eq(2)
+
+        expect(subject[0].comment_tokens.size).to eq(2)
+        expect(subject[0].comment_tokens[0]).to be_an_instance_of(RDocRuboCop::Token::CommentToken)
+        expect(subject[0].comment_tokens[0].lineno).to eq(2)
+        expect(subject[0].comment_tokens[0].token).to eq("#--\n")
+        expect(subject[0].comment_tokens[1]).to be_an_instance_of(RDocRuboCop::Token::CommentToken)
+        expect(subject[0].comment_tokens[1].lineno).to eq(3)
+        expect(subject[0].comment_tokens[1].token).to eq("# comment\n")
+
+        expect(subject[1].comment_tokens.size).to eq(1)
+        expect(subject[1].comment_tokens[0]).to be_an_instance_of(RDocRuboCop::Token::CommentToken)
+        expect(subject[1].comment_tokens[0].lineno).to eq(4)
+        expect(subject[1].comment_tokens[0].token).to eq("# :nodoc:\n")
+      end
+    end
   end
 end

--- a/spec/rdoc_rubocop/comment_extractor_spec.rb
+++ b/spec/rdoc_rubocop/comment_extractor_spec.rb
@@ -2,49 +2,52 @@ require "spec_helper"
 
 RSpec.describe RDocRuboCop::CommentExtractor do
   describe "#extract" do
-    let(:source) do
-      <<-RUBY.strip_heredoc
-        # comment1-1
-        # comment1-2
-        # comment1-3
-
-        class Foo
-          # comment-in-Foo-1
-          # comment-in-Foo-2
-          # comment-in-Foo-3
-          def foo
-            "foo"
-          end
-          module_function :foo
-        end
-      RUBY
-    end
     let(:source_file) { RDocRuboCop::SourceFile.new(source, "foo.rb") }
 
     subject { described_class.new(source_file).extract }
 
-    it do
-      expect(subject.size).to eq(2)
+    context "when the code has two comments" do
+      let(:source) do
+        <<-RUBY.strip_heredoc
+          # comment1-1
+          # comment1-2
+          # comment1-3
 
-      expect(subject[0].comment_tokens[0]).to be_an_instance_of(RDocRuboCop::Token::CommentToken)
-      expect(subject[0].comment_tokens[0].lineno).to eq(1)
-      expect(subject[0].comment_tokens[0].token).to eq("# comment1-1\n")
-      expect(subject[0].comment_tokens[1]).to be_an_instance_of(RDocRuboCop::Token::CommentToken)
-      expect(subject[0].comment_tokens[1].lineno).to eq(2)
-      expect(subject[0].comment_tokens[1].token).to eq("# comment1-2\n")
-      expect(subject[0].comment_tokens[2]).to be_an_instance_of(RDocRuboCop::Token::CommentToken)
-      expect(subject[0].comment_tokens[2].lineno).to eq(3)
-      expect(subject[0].comment_tokens[2].token).to eq("# comment1-3\n")
+          class Foo
+            # comment-in-Foo-1
+            # comment-in-Foo-2
+            # comment-in-Foo-3
+            def foo
+              "foo"
+            end
+            module_function :foo
+          end
+        RUBY
+      end
 
-      expect(subject[1].comment_tokens[0]).to be_an_instance_of(RDocRuboCop::Token::CommentToken)
-      expect(subject[1].comment_tokens[0].lineno).to eq(6)
-      expect(subject[1].comment_tokens[0].token).to eq("# comment-in-Foo-1\n")
-      expect(subject[1].comment_tokens[1]).to be_an_instance_of(RDocRuboCop::Token::CommentToken)
-      expect(subject[1].comment_tokens[1].lineno).to eq(7)
-      expect(subject[1].comment_tokens[1].token).to eq("# comment-in-Foo-2\n")
-      expect(subject[1].comment_tokens[2]).to be_an_instance_of(RDocRuboCop::Token::CommentToken)
-      expect(subject[1].comment_tokens[2].lineno).to eq(8)
-      expect(subject[1].comment_tokens[2].token).to eq("# comment-in-Foo-3\n")
+      it "should returns two instances of Comment" do
+        expect(subject.size).to eq(2)
+
+        expect(subject[0].comment_tokens[0]).to be_an_instance_of(RDocRuboCop::Token::CommentToken)
+        expect(subject[0].comment_tokens[0].lineno).to eq(1)
+        expect(subject[0].comment_tokens[0].token).to eq("# comment1-1\n")
+        expect(subject[0].comment_tokens[1]).to be_an_instance_of(RDocRuboCop::Token::CommentToken)
+        expect(subject[0].comment_tokens[1].lineno).to eq(2)
+        expect(subject[0].comment_tokens[1].token).to eq("# comment1-2\n")
+        expect(subject[0].comment_tokens[2]).to be_an_instance_of(RDocRuboCop::Token::CommentToken)
+        expect(subject[0].comment_tokens[2].lineno).to eq(3)
+        expect(subject[0].comment_tokens[2].token).to eq("# comment1-3\n")
+
+        expect(subject[1].comment_tokens[0]).to be_an_instance_of(RDocRuboCop::Token::CommentToken)
+        expect(subject[1].comment_tokens[0].lineno).to eq(6)
+        expect(subject[1].comment_tokens[0].token).to eq("# comment-in-Foo-1\n")
+        expect(subject[1].comment_tokens[1]).to be_an_instance_of(RDocRuboCop::Token::CommentToken)
+        expect(subject[1].comment_tokens[1].lineno).to eq(7)
+        expect(subject[1].comment_tokens[1].token).to eq("# comment-in-Foo-2\n")
+        expect(subject[1].comment_tokens[2]).to be_an_instance_of(RDocRuboCop::Token::CommentToken)
+        expect(subject[1].comment_tokens[2].lineno).to eq(8)
+        expect(subject[1].comment_tokens[2].token).to eq("# comment-in-Foo-3\n")
+      end
     end
   end
 end


### PR DESCRIPTION
When adjacent comments exist, `CommentExtractor` extract it as one comment:

**source code**
```ruby
#--
# comment
def foo; end # :nodoc:
```
**before**

```
#<RDocRuboCop::Comment:0x000055c89476cd68
 @comment_tokens=
  [#<RDocRuboCop::Token::CommentToken:0x000055c89476e5c8 @locate=[1, 0], @state=EXPR_BEG, @token="#--\n", @type=:on_comment>,
   #<RDocRuboCop::Token::CommentToken:0x000055c89476e5a0 @locate=[2, 0], @state=EXPR_BEG, @token="# comment\n", @type=:on_comment>,
   #<RDocRuboCop::Token::CommentToken:0x000055c89476e438 @locate=[3, 13], @state=EXPR_END, @token="# :nodoc:\n", @type=:on_comment>],
   ...>]
```

**after**

```
[#<RDocRuboCop::Comment:0x00005626fd9fc1b0
  @comment_tokens=
   [#<RDocRuboCop::Token::CommentToken:0x00005626fd9fd560 @locate=[1, 0], @state=EXPR_BEG, @token="#--\n", @type=:on_comment>,
    #<RDocRuboCop::Token::CommentToken:0x00005626fd9fd538 @locate=[2, 0], @state=EXPR_BEG, @token="# comment\n", @type=:on_comment>],
   ...>,
 #<RDocRuboCop::Comment:0x00005626fd9fc110
  @comment_tokens=[#<RDocRuboCop::Token::CommentToken:0x00005626fd9fd3f8 @locate=[3, 13], @state=EXPR_END, @token="# :nodoc:\n", @type=:on_comment>],
   ...>]
```